### PR TITLE
Add factories and achievements to web version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Paperfold Studio is an idle-clicker game. This repository contains the original 
 
 ## Playing in the Browser
 
-Open `Web/index.html` in any modern browser. The web version implements folding, assistants, origami set progression, skills, prestige and saving/loading using `localStorage`.
+Open `Web/index.html` in any modern browser. The web version implements folding, assistants, factories, achievements, a daily bonus system, an expanded skill tree, origami set progression, prestige and saving/loading using `localStorage`.
 
 ## Unity Project Requirements
 
@@ -41,7 +41,10 @@ Open `Web/index.html` in any modern browser. The web version implements folding,
 
 - **Origami Sets:** Edit `ProgressionSystem.cs` or modify `Web/game.js` to add new sets.
 - **Skills:** Adjust `SkillTree.cs` or the browser code to define new upgrades.
+- **Achievements:** Extend the `achievements` array in `Web/game.js`.
+- **Factories:** Tune `factoryLevel` or costs in the browser script.
 - **Gallery Assets:** Place art in `Assets/Addressables` and mark them as addressable via Unity's Addressables system.
+- **Daily Bonus:** The browser version grants 50 folds once per day on load.
 
 ## Project Version
 

--- a/Web/game.js
+++ b/Web/game.js
@@ -5,8 +5,11 @@ const rateDisplay = document.getElementById('rate-display');
 const foldButton = document.getElementById('fold-button');
 const hireAssistantButton = document.getElementById('hire-assistant-button');
 const assistantInfo = document.getElementById('assistant-info');
+const factoryInfo = document.getElementById('factory-info');
+const buyFactoryButton = document.getElementById('buy-factory-button');
 const setList = document.getElementById('set-list');
 const skillList = document.getElementById('skill-list');
+const achievementList = document.getElementById('achievement-list');
 const skillPointsEl = document.getElementById('skill-points');
 const prestigeInfo = document.getElementById('prestige-info');
 const prestigeButton = document.getElementById('prestige-button');
@@ -22,28 +25,58 @@ let skillPoints = 0;
 let prestigeCount = 0;
 const prestigeBonus = 0.1;
 
+let factoryLevel = 0;
+const baseFactoryCost = 1000;
+let factoryFoldsPerSecond = 5;
+
+let achievements = [
+  { name: 'First Fold', achieved: false, check: () => foldCount >= 1 },
+  { name: '100 Folds', achieved: false, check: () => foldCount >= 100 },
+  { name: 'First Assistant', achieved: false, check: () => assistantLevel >= 1 },
+  { name: 'First Factory', achieved: false, check: () => factoryLevel >= 1 },
+  { name: 'Prestigious', achieved: false, check: () => prestigeCount >= 1 }
+];
+
 let origamiSets = [
   { name: 'Crane Set', cost: 100, completed: false },
-  { name: 'Flower Set', cost: 500, completed: false }
+  { name: 'Flower Set', cost: 500, completed: false },
+  { name: 'Star Set', cost: 1000, completed: false },
+  { name: 'Dragon Set', cost: 5000, completed: false },
+  { name: 'Animal Set', cost: 10000, completed: false },
+  { name: 'Mythical Set', cost: 50000, completed: false },
+  { name: 'Master Set', cost: 250000, completed: false }
 ];
 
 let skills = [
   { name: 'Faster Assistants', cost: 1, purchased: false },
-  { name: '+1 Fold/Click', cost: 1, purchased: false }
+  { name: '+1 Fold/Click', cost: 1, purchased: false },
+  { name: 'Auto-fold', cost: 3, purchased: false },
+  { name: 'Better Paper', cost: 5, purchased: false },
+  { name: 'Factory Efficiency', cost: 10, purchased: false },
+  { name: 'Double Click Power', cost: 10, purchased: false },
+  { name: 'Assistant Manager', cost: 20, purchased: false },
+  { name: 'Factory Manager', cost: 20, purchased: false }
 ];
 
 function assistantCost() {
   return Math.ceil(baseAssistantCost * Math.pow(1.15, assistantLevel));
 }
 
+function factoryCost() {
+  return Math.ceil(baseFactoryCost * Math.pow(1.2, factoryLevel));
+}
+
 function foldsPerSecond() {
-  return assistantLevel * baseFoldsPerSecond * (1 + prestigeCount * prestigeBonus);
+  const assistantRate = assistantLevel * baseFoldsPerSecond;
+  const factoryRate = factoryLevel * factoryFoldsPerSecond;
+  return (assistantRate + factoryRate) * (1 + prestigeCount * prestigeBonus);
 }
 
 function updateDisplay() {
   foldDisplay.textContent = `Folds: ${Math.floor(foldCount)}`;
   rateDisplay.textContent = `Folds/s: ${foldsPerSecond().toFixed(1)}`;
   assistantInfo.textContent = `Level: ${assistantLevel} (${foldsPerSecond().toFixed(1)}/s) - Cost: ${assistantCost()}`;
+  factoryInfo.textContent = `Level: ${factoryLevel} (${(factoryLevel * factoryFoldsPerSecond).toFixed(1)}/s) - Cost: ${factoryCost()}`;
   skillPointsEl.textContent = skillPoints;
   prestigeInfo.textContent = `Prestige count: ${prestigeCount}`;
 
@@ -66,6 +99,15 @@ function updateDisplay() {
     li.appendChild(btn);
     skillList.appendChild(li);
   });
+
+  // Update achievements
+  achievementList.innerHTML = '';
+  achievements.forEach(ach => {
+    const li = document.createElement('li');
+    li.textContent = ach.name;
+    if (ach.achieved) li.classList.add('unlocked');
+    achievementList.appendChild(li);
+  });
 }
 
 function addFold(amount) {
@@ -83,6 +125,18 @@ function purchaseSkill(index) {
       baseFoldsPerSecond += 0.5;
     } else if (skill.name === '+1 Fold/Click') {
       foldsPerClick += 1;
+    } else if (skill.name === 'Auto-fold') {
+      baseFoldsPerSecond += 1;
+    } else if (skill.name === 'Better Paper') {
+      foldsPerClick *= 2;
+    } else if (skill.name === 'Factory Efficiency') {
+      factoryFoldsPerSecond += 2;
+    } else if (skill.name === 'Double Click Power') {
+      foldsPerClick *= 2;
+    } else if (skill.name === 'Assistant Manager') {
+      baseFoldsPerSecond += 2;
+    } else if (skill.name === 'Factory Manager') {
+      factoryFoldsPerSecond += 3;
     }
     updateDisplay();
   }
@@ -97,6 +151,14 @@ function checkSets() {
   });
 }
 
+function checkAchievements() {
+  achievements.forEach(ach => {
+    if (!ach.achieved && ach.check()) {
+      ach.achieved = true;
+    }
+  });
+}
+
 function hireAssistant() {
   const cost = assistantCost();
   if (foldCount >= cost) {
@@ -106,11 +168,21 @@ function hireAssistant() {
   }
 }
 
+function buyFactory() {
+  const cost = factoryCost();
+  if (foldCount >= cost) {
+    foldCount -= cost;
+    factoryLevel += 1;
+    updateDisplay();
+  }
+}
+
 function prestige() {
   prestigeCount += 1;
   foldCount = 0;
   skillPoints = 0;
   assistantLevel = 0;
+  factoryLevel = 0;
   baseFoldsPerSecond = 1;
   foldsPerClick = 1;
   origamiSets.forEach(set => set.completed = false);
@@ -121,6 +193,7 @@ function prestige() {
 function tick() {
   addFold(foldsPerSecond());
   checkSets();
+  checkAchievements();
 }
 
 function saveGame() {
@@ -129,10 +202,13 @@ function saveGame() {
     foldsPerClick,
     assistantLevel,
     baseFoldsPerSecond,
+    factoryLevel,
+    factoryFoldsPerSecond,
     skillPoints,
     prestigeCount,
     origamiSets,
-    skills
+    skills,
+    achievements
   };
   localStorage.setItem('paperfold-save', JSON.stringify(data));
 }
@@ -146,14 +222,27 @@ function loadGame() {
     foldsPerClick = data.foldsPerClick || 1;
     assistantLevel = data.assistantLevel || 0;
     baseFoldsPerSecond = data.baseFoldsPerSecond || 1;
+    factoryLevel = data.factoryLevel || 0;
+    factoryFoldsPerSecond = data.factoryFoldsPerSecond || 5;
     skillPoints = data.skillPoints || 0;
     prestigeCount = data.prestigeCount || 0;
     origamiSets = data.origamiSets || origamiSets;
     skills = data.skills || skills;
+    achievements = data.achievements || achievements;
   } catch (e) {
     console.error('Failed to load save', e);
   }
   updateDisplay();
+}
+
+function dailyBonus() {
+  const today = new Date().toDateString();
+  const last = localStorage.getItem('paperfold-lastbonus');
+  if (today !== last) {
+    foldCount += 50;
+    localStorage.setItem('paperfold-lastbonus', today);
+    alert('Daily bonus! +50 folds');
+  }
 }
 
 // Event wiring
@@ -162,6 +251,7 @@ foldButton.addEventListener('click', () => {
 });
 
 hireAssistantButton.addEventListener('click', hireAssistant);
+buyFactoryButton.addEventListener('click', buyFactory);
 prestigeButton.addEventListener('click', prestige);
 saveButton.addEventListener('click', () => {
   saveGame();
@@ -174,6 +264,7 @@ loadButton.addEventListener('click', () => {
 
 document.addEventListener('DOMContentLoaded', () => {
   loadGame();
+  dailyBonus();
   updateDisplay();
   setInterval(tick, 1000);
 });

--- a/Web/index.html
+++ b/Web/index.html
@@ -18,11 +18,18 @@
     <div id="assistant-info">Level: 0 (0/s) - Cost: 10</div>
     <button id="hire-assistant-button">Hire/Upgrade Assistant</button>
 
+    <h2>Factory</h2>
+    <div id="factory-info">Level: 0 (0/s) - Cost: 1000</div>
+    <button id="buy-factory-button">Build/Upgrade Factory</button>
+
     <h2>Origami Sets</h2>
     <ul id="set-list"></ul>
 
     <h2>Skills (<span id="skill-points">0</span> points)</h2>
     <ul id="skill-list"></ul>
+
+    <h2>Achievements</h2>
+    <ul id="achievement-list"></ul>
 
     <h2>Prestige</h2>
     <div id="prestige-info">Prestige count: 0</div>

--- a/Web/style.css
+++ b/Web/style.css
@@ -58,3 +58,7 @@ ul {
 li {
   margin: 5px 0;
 }
+
+#achievement-list li.unlocked {
+  color: green;
+}


### PR DESCRIPTION
## Summary
- expand web version with factories, achievements and daily bonus
- add new skills and origami sets
- update styles and UI elements
- document new systems in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6851e2b49f7883298acc956511ffaa33